### PR TITLE
Possible fixes for some browsers and minor changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,16 +16,15 @@
             }
             #info {
                 padding: 0 20px;
-                margin: 0 20px;
                 border-radius: 16px;
                 background-color:rgba(255, 255, 255, 0.1);
             }
             .t_gradient {
                 background: linear-gradient(90deg, #6164ff 0%, #ff5656 50%, #ffac4d 100%);
                 background-clip: text;
+                -webkit-background-clip: text;
                 color: transparent;
             }
-            h1 { margin: 16px 0; }
         </style>
     </head>
     <body>

--- a/shared.css
+++ b/shared.css
@@ -3,11 +3,16 @@
 
 * { box-sizing: border-box; }
 
-body {
-    min-height: 100vh;
-    min-width: 100vw;
+html, body {
     margin: 0;
     padding: 0;
+}
+
+body {
+    min-height: 100vh;
+    min-height: -webkit-fill-available;
+    min-height: fill-available;
+    font-size: 16px;
     font-family: 'Roboto', sans-serif;
     line-height: 1.2;
 }
@@ -24,7 +29,9 @@ a:hover, a:focus, a:active {
     text-decoration: underline;
 }
 
-h3 { margin: 25px auto auto auto; }
+h1, h2, h3, h4, h5, h6 {
+    margin: 16px 0;
+}
 
 code, .code_i { display: inline; padding: 2px 4px; font-family: 'Roboto Mono', monospace; line-height: 1.1; font-size: 15px; color: #cccccc; background-color: rgba(0, 0, 0, 0.5); border-radius: 5px; white-space: nowrap }
 


### PR DESCRIPTION
- fixed gradient text on some browsers by adding a prefixed `background-clip` with `-webkit-` (see the [caniuse page](https://caniuse.com/background-clip-text) for it)
- fixed body height on some mobile browsers by making use of [intrinsic sizing](https://caniuse.com/intrinsic-width). Solution advocated for by [Matt Smith](https://twitter.com/allthingssmitty/status/1254151507412496384), although it appears to be quite non-standard, and may not work.
- moved header margin to shared.css and applied it to the rest of the header elements
- added font size to body for consistency
- removed unnesscary properties regarding body
- ~~removed #info margin property, as there's nothing for it to effect~~ edit: forgot about the sides of the screen on mobile
- removed unnesscary h3 rule

Site should look identical to as it was before on desktops. Didn't change any of the margins or padding.