### PR TITLE
Make cordon consistent and hide scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
                 flex-direction: column;
                 justify-content: space-evenly;
                 align-items: center;
+                overflow: hidden;
+                /* Overflow can and will cause problems related to scroll if you add more content */
             }
             #info {
                 padding: 0 20px;
@@ -55,7 +57,7 @@
 
             function init() {
                 scene = new THREE.Scene();
-                camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+                camera = new THREE.PerspectiveCamera(75, 1280 / 720, 0.1, 1000);
                 camera.position.set(100, 80, 20)
                 camera.lookAt(scene.position.x, scene.position.y + 35, scene.position.z);
 
@@ -72,7 +74,7 @@
                 });
 
                 renderer = new THREE.WebGLRenderer();
-                renderer.setSize(window.innerWidth, window.innerHeight);
+                renderer.setSize(1280, 720);
                 let elem = renderer.domElement;
                 elem.id = "cordon";
                 document.body.appendChild(elem);


### PR DESCRIPTION
- Cordon will now render at the same size regardless of initial page load or resize. Not sure if this is better, but it's a lot more consistent
  - A better solution would probably involve math and dynamically resizing cordon with max and minimum caps. My initial idea was to make the canvas's size dictated by CSS in the same way the body is, but this didn't work because the canvas's "size" actually controls the render.
- Scroll bars caused by cordon's canvas are now hidden